### PR TITLE
improve release build clarity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,6 @@ jobs:
           semver: ${{ github.event.inputs.semver }}
           sync-semver-tags: true
           build-command: |
-            echo 'installing husky hooks..'
-            npm ci
+            npm ci --ignore-scripts
+            npm run build
+            git add dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
           semver: ${{ github.event.inputs.semver }}
           sync-semver-tags: true
           build-command: |
-            npm ci --ignore-scripts
+            npm ci
             npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,3 @@ jobs:
           build-command: |
             npm ci --ignore-scripts
             npm run build
-            git add dist


### PR DESCRIPTION
As proposal to this comment: https://github.com/nearform/github-action-notify-release/pull/130#issuecomment-997234099

I thought that adding the `echo` command to declare the intention was a tradeoff.

Changing the build script to this one will not build the GHA twice

