### PR TITLE
Feat/393 post comment when issue is closed as not planned

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -5,6 +5,8 @@ on:
       - main
   release:
     types: [published]
+  issues:
+    types: [closed]
   schedule:
     - cron: '30 8 * * *'
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+  issues:
+    types: [closed]
   schedule:
     - cron: '30 8 * * *'
 jobs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -18248,7 +18248,7 @@ async function addComment(token, notifyAfter, issueId) {
     {
       owner,
       repo,
-      issue_number: issueId,
+      issue_number: issueId.toString(),
       body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
         notifyDate
       )}.`,

--- a/dist/index.js
+++ b/dist/index.js
@@ -18583,9 +18583,9 @@ async function run() {
   )
 
   const isClosingIssue = context.eventName === 'closed'
+  console.log('eventName: ', context.eventName)
+  console.log('context: ', context)
   if (isClosingIssue) {
-    console.log('eventName: ', context.eventName)
-    console.log('context: ', context)
     return
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18162,7 +18162,8 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const { number: issueNo } = await createIssue(token, issueBody)
+    const issueNo = await createIssue(token, issueBody)
+    console.log(issueNo)
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }
@@ -18231,7 +18232,7 @@ function getClosingIssueDetails(context) {
     isNotifyReleaseIssue,
   }
 
-  logInfo(`Closing issue details: ${closingIssueDetails}`)
+  logInfo(`Closing issue details: ${JSON.stringify(closingIssueDetails)}`)
 
   return closingIssueDetails
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -18671,16 +18671,18 @@ async function run() {
     stateClosedNotPlanned,
     issueNumber,
   } = getClosingIssueDetails(context)
-  if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
-    await addComment(token, notifyAfter, issueNumber)
-    return
-  } else if (isClosing) {
+
+  if (!isClosing) {
+    const commitMessageLines = Number(core.getInput('commit-messages-lines'))
+    await runAction(token, notifyAfter, commitMessageLines)
     return
   }
 
-  const commitMessageLines = Number(core.getInput('commit-messages-lines'))
+  if (!isNotifyReleaseIssue || !stateClosedNotPlanned) {
+    return
+  }
 
-  await runAction(token, notifyAfter, commitMessageLines)
+  await addComment(token, notifyAfter, issueNumber)
 }
 
 run().catch((err) => core.setFailed(err))

--- a/dist/index.js
+++ b/dist/index.js
@@ -18059,7 +18059,7 @@ module.exports = {
 
 const github = __nccwpck_require__(5438)
 const { logInfo } = __nccwpck_require__(4353)
-const { isStale } = __nccwpck_require__(3590)
+const { isStale, getNotifyDate } = __nccwpck_require__(3590)
 const fs = __nccwpck_require__(7147)
 const path = __nccwpck_require__(1017)
 const { promisify } = __nccwpck_require__(3837)
@@ -18073,7 +18073,6 @@ const {
   ISSUES_EVENT_NAME,
   STATE_CLOSED_NOT_PLANNED,
 } = __nccwpck_require__(4438)
-const { notifyAfterToMs } = __nccwpck_require__(3590)
 
 function registerHandlebarHelpers(config) {
   const { commitMessageLines } = config
@@ -18238,7 +18237,7 @@ function getClosingIssueDetails(context) {
 }
 
 async function addComment(token, notifyAfter, issueNumber) {
-  const notifyDate = notifyAfterToMs(notifyAfter)
+  const notifyDate = getNotifyDate(notifyAfter)
 
   const octokit = github.getOctokit(token)
   const { owner, repo } = github.context.repo
@@ -18249,9 +18248,7 @@ async function addComment(token, notifyAfter, issueNumber) {
       owner,
       repo,
       issue_number: issueNumber,
-      body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
-        notifyDate
-      )}.`,
+      body: `This issue has been snoozed. A new issue will be opened for you on ${notifyDate}.`,
     }
   )
 }
@@ -18458,11 +18455,22 @@ function parseNotifyAfter(notifyAfter, staleDays) {
   return isNaN(Number(staleDays)) ? staleDays : staleDaysToStr(staleDays)
 }
 
+function getNotifyDate(input) {
+  const stringToMs = ms(input)
+
+  if (isNaN(stringToMs)) {
+    throw new Error('Invalid time value')
+  }
+
+  return new Date(Date.now() + stringToMs)
+}
+
 module.exports = {
   isSomeCommitStale,
   isStale,
   parseNotifyAfter,
   notifyAfterToMs,
+  getNotifyDate,
   staleDaysToStr,
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4287,7 +4287,7 @@ const core = __nccwpck_require__(2186)
  */
 function logActionRefWarning() {
   const actionRef = process.env.GITHUB_ACTION_REF
-  const repoName = process.env.GITHUB_REPOSITORY
+  const repoName = process.env.GITHUB_ACTION_REPOSITORY
 
   if (actionRef === 'main' || actionRef === 'master') {
     core.warning(
@@ -4303,8 +4303,24 @@ function logActionRefWarning() {
   }
 }
 
+/**
+ * Displays warning message if the repository is under the nearform organisation
+ */
+function logRepoWarning() {
+  const repoName = process.env.GITHUB_ACTION_REPOSITORY
+  const repoOrg = repoName.split('/')[0]
+
+  if (repoOrg != 'nearform-actions') {
+    core.warning(
+      `'${repoOrg}' is no longer a valid organisation for this action.` +
+        `Please update it to be under the 'nearform-actions' organisation.`
+    )
+  }
+}
+
 module.exports = {
-  logActionRefWarning
+  logActionRefWarning,
+  logRepoWarning
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4287,7 +4287,7 @@ const core = __nccwpck_require__(2186)
  */
 function logActionRefWarning() {
   const actionRef = process.env.GITHUB_ACTION_REF
-  const repoName = process.env.GITHUB_REPOSITORY
+  const repoName = process.env.GITHUB_ACTION_REPOSITORY
 
   if (actionRef === 'main' || actionRef === 'master') {
     core.warning(
@@ -4303,8 +4303,24 @@ function logActionRefWarning() {
   }
 }
 
+/**
+ * Displays warning message if the repository is under the nearform organisation
+ */
+function logRepoWarning() {
+  const repoName = process.env.GITHUB_ACTION_REPOSITORY
+  const repoOrg = repoName.split('/')[0]
+
+  if (repoOrg != 'nearform-actions') {
+    core.warning(
+      `'${repoOrg}' is no longer a valid organisation for this action.` +
+        `Please update it to be under the 'nearform-actions' organisation.`
+    )
+  }
+}
+
 module.exports = {
-  logActionRefWarning
+  logActionRefWarning,
+  logRepoWarning
 }
 
 
@@ -12225,7 +12241,7 @@ exports.implementation = class URLImpl {
 
 /***/ }),
 
-/***/ 4720:
+/***/ 653:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -12435,7 +12451,7 @@ module.exports = {
 "use strict";
 
 
-exports.URL = __nccwpck_require__(4720)["interface"];
+exports.URL = __nccwpck_require__(653)["interface"];
 exports.serializeURL = __nccwpck_require__(33).serializeURL;
 exports.serializeURLOrigin = __nccwpck_require__(33).serializeURLOrigin;
 exports.basicURLParse = __nccwpck_require__(33).basicURLParse;
@@ -18017,7 +18033,7 @@ function wrappy (fn, cb) {
 "use strict";
 
 const github = __nccwpck_require__(5438)
-const { logInfo } = __nccwpck_require__(653)
+const { logInfo } = __nccwpck_require__(4353)
 const { isStale } = __nccwpck_require__(3590)
 const fs = __nccwpck_require__(7147)
 const path = __nccwpck_require__(1017)
@@ -18172,7 +18188,7 @@ module.exports = {
 
 /***/ }),
 
-/***/ 653:
+/***/ 4353:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -18195,7 +18211,7 @@ exports.logWarning = log(warning)
 "use strict";
 
 
-const { logInfo, logWarning } = __nccwpck_require__(653)
+const { logInfo, logWarning } = __nccwpck_require__(4353)
 const { getLatestRelease, getUnreleasedCommits } = __nccwpck_require__(2026)
 const {
   createOrUpdateIssue,
@@ -18317,7 +18333,7 @@ module.exports = {
 "use strict";
 
 const ms = __nccwpck_require__(900)
-const { logWarning } = __nccwpck_require__(653)
+const { logWarning } = __nccwpck_require__(4353)
 
 function notifyAfterToMs(input) {
   const stringToMs = ms(input)
@@ -18552,6 +18568,7 @@ var __webpack_exports__ = {};
 
 const core = __nccwpck_require__(2186)
 const toolkit = __nccwpck_require__(2020)
+const { context } = __nccwpck_require__(5438)
 const { parseNotifyAfter } = __nccwpck_require__(3590)
 const { runAction } = __nccwpck_require__(1254)
 
@@ -18564,6 +18581,13 @@ async function run() {
     core.getInput('notify-after'),
     core.getInput('stale-days')
   )
+
+  const isClosingIssue = context.eventName === 'closed'
+  if (isClosingIssue) {
+    console.log('eventName: ', context.eventName)
+    console.log('context: ', context)
+    return
+  }
 
   const commitMessageLines = Number(core.getInput('commit-messages-lines'))
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18211,14 +18211,14 @@ function getClosingIssueDetails(context) {
 
   if (!issue) {
     return {
-      issueId: undefined,
+      issueNumber: undefined,
       isClosing: false,
       stateClosedNotPlanned: false,
       isNotifyReleaseIssue: false,
     }
   }
 
-  const { id, state, state_reason: stateReason, labels } = issue
+  const { number, state, state_reason: stateReason, labels } = issue
   const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
   const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
   const isNotifyReleaseIssue = labels.some(
@@ -18226,7 +18226,7 @@ function getClosingIssueDetails(context) {
   )
 
   const closingIssueDetails = {
-    issueId: id,
+    issueNumber: number,
     isClosing,
     stateClosedNotPlanned,
     isNotifyReleaseIssue,
@@ -18237,7 +18237,7 @@ function getClosingIssueDetails(context) {
   return closingIssueDetails
 }
 
-async function addComment(token, notifyAfter, issueId) {
+async function addComment(token, notifyAfter, issueNumber) {
   const notifyDate = notifyAfterToMs(notifyAfter)
 
   const octokit = github.getOctokit(token)
@@ -18248,7 +18248,7 @@ async function addComment(token, notifyAfter, issueId) {
     {
       owner,
       repo,
-      issue_number: issueId.toString(),
+      issue_number: issueNumber,
       body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
         notifyDate
       )}.`,
@@ -18665,10 +18665,14 @@ async function run() {
     core.getInput('stale-days')
   )
 
-  const { isClosing, isNotifyReleaseIssue, stateClosedNotPlanned, issueId } =
-    getClosingIssueDetails(context)
+  const {
+    isClosing,
+    isNotifyReleaseIssue,
+    stateClosedNotPlanned,
+    issueNumber,
+  } = getClosingIssueDetails(context)
   if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
-    await addComment(token, notifyAfter, issueId)
+    await addComment(token, notifyAfter, issueNumber)
     return
   } else if (isClosing) {
     return

--- a/dist/index.js
+++ b/dist/index.js
@@ -18226,6 +18226,21 @@ function getIsSnoozingIssue(context) {
   return isSnoozingIssue
 }
 
+function getIsClosingIssue(context) {
+  const { eventName, payload } = context
+  const { issue } = payload
+
+  if (!issue) {
+    return false
+  }
+
+  const { state } = issue
+
+  const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
+
+  return isClosing
+}
+
 async function addSnoozingComment(token, notifyAfter, issueNumber) {
   logInfo('Adding a snoozing comment to the issue.')
 
@@ -18255,6 +18270,7 @@ module.exports = {
   closeIssue,
   isSnoozed,
   getIsSnoozingIssue,
+  getIsClosingIssue,
   addSnoozingComment,
 }
 
@@ -18655,7 +18671,11 @@ const toolkit = __nccwpck_require__(2020)
 const { context } = __nccwpck_require__(5438)
 const { parseNotifyAfter } = __nccwpck_require__(3590)
 const { runAction } = __nccwpck_require__(1254)
-const { getIsSnoozingIssue, addSnoozingComment } = __nccwpck_require__(5465)
+const {
+  getIsSnoozingIssue,
+  getIsClosingIssue,
+  addSnoozingComment,
+} = __nccwpck_require__(5465)
 const { logInfo } = __nccwpck_require__(4353)
 
 async function run() {
@@ -18675,6 +18695,12 @@ async function run() {
     logInfo('Snoozing issue ...')
     const { number } = context.issue
     return addSnoozingComment(token, notifyAfter, number)
+  }
+
+  const isClosing = getIsClosingIssue(context)
+  if (isClosing) {
+    logInfo('Closing issue. Nothing to do ...')
+    return
   }
 
   logInfo('Workflow dispatched or release published ...')

--- a/dist/index.js
+++ b/dist/index.js
@@ -18231,12 +18231,14 @@ function getClosingIssueDetails(context) {
     isNotifyReleaseIssue,
   }
 
-  logInfo(closingIssueDetails)
+  logInfo(`Closing issue details: ${closingIssueDetails}`)
 
   return closingIssueDetails
 }
 
 async function addComment(token, notifyAfter, issueNumber) {
+  logInfo('Adding a comment to the issue.')
+
   const notifyDate = getNotifyDate(notifyAfter)
 
   const octokit = github.getOctokit(token)
@@ -18251,6 +18253,8 @@ async function addComment(token, notifyAfter, issueNumber) {
       body: `This issue has been snoozed. A new issue will be opened for you on ${notifyDate}.`,
     }
   )
+
+  logInfo('Comment added to the issue.')
 }
 
 module.exports = {
@@ -18662,6 +18666,7 @@ const { context } = __nccwpck_require__(5438)
 const { parseNotifyAfter } = __nccwpck_require__(3590)
 const { runAction } = __nccwpck_require__(1254)
 const { getClosingIssueDetails, addComment } = __nccwpck_require__(5465)
+const { logInfo } = __nccwpck_require__(4353)
 
 async function run() {
   toolkit.logActionRefWarning()
@@ -18682,12 +18687,16 @@ async function run() {
   } = getClosingIssueDetails(context)
 
   if (!isClosing) {
+    logInfo('Workflow dispatched or release published ...')
     const commitMessageLines = Number(core.getInput('commit-messages-lines'))
     await runAction(token, notifyAfter, commitMessageLines)
     return
   }
 
+  logInfo('Issue is closing ...')
+
   if (!isNotifyReleaseIssue || !stateClosedNotPlanned) {
+    logInfo('Nothing to do.')
     return
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -18162,8 +18162,8 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const issueNo = await createIssue(token, issueBody)
-    console.log(issueNo)
+    const { data } = await createIssue(token, issueBody)
+    const { number: issueNo } = data
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -18219,21 +18219,22 @@ function getClosingIssueDetails(context) {
   }
 
   const { id, state, state_reason: stateReason, labels } = issue
-  console.log('id: ', id)
-  console.log('state: ', state)
-  console.log('state_reason: ', stateReason)
-  console.log('labels: ', labels)
-  console.log('stringified labels: ', JSON.stringify(labels))
   const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
   const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
-  const isNotifyReleaseIssue = labels.includes(ISSUE_LABEL)
+  const isNotifyReleaseIssue = labels.some(
+    (label) => label.name === ISSUE_LABEL
+  )
 
-  return {
+  const closingIssueDetails = {
     issueId: id,
     isClosing,
     stateClosedNotPlanned,
     isNotifyReleaseIssue,
   }
+
+  logInfo(closingIssueDetails)
+
+  return closingIssueDetails
 }
 
 async function addComment(token, notifyAfter, issueId) {
@@ -18666,8 +18667,6 @@ async function run() {
 
   const { isClosing, isNotifyReleaseIssue, stateClosedNotPlanned, issueId } =
     getClosingIssueDetails(context)
-  console.log('isClosing: ', isClosing)
-  console.log('issueId: ', issueId)
   if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
     await addComment(token, notifyAfter, issueId)
     return

--- a/dist/index.js
+++ b/dist/index.js
@@ -18162,7 +18162,7 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const issueNo = await createIssue(token, issueBody)
+    const { number: issueNo } = await createIssue(token, issueBody)
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -18658,6 +18658,8 @@ async function run() {
   )
 
   const { isClosing, issueId } = getClosingIssueDetails(context)
+  console.log('isClosing: ', isClosing)
+  console.log('issueId: ', issueId)
   if (isClosing) {
     await addComment(token, notifyAfter, issueId)
     return

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const ISSUE_LABEL = 'notify-release'
+const ISSUE_TITLE = 'Release pending!'
+const STATE_OPEN = 'open'
+const STATE_CLOSED = 'closed'
+const STATE_CLOSED_NOT_PLANNED = 'not_planned'
+const ISSUES_EVENT_NAME = 'issues'
+
+module.exports = {
+  ISSUE_LABEL,
+  ISSUE_TITLE,
+  STATE_OPEN,
+  STATE_CLOSED,
+  STATE_CLOSED_NOT_PLANNED,
+  ISSUES_EVENT_NAME,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -22,16 +22,18 @@ async function run() {
     stateClosedNotPlanned,
     issueNumber,
   } = getClosingIssueDetails(context)
-  if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
-    await addComment(token, notifyAfter, issueNumber)
-    return
-  } else if (isClosing) {
+
+  if (!isClosing) {
+    const commitMessageLines = Number(core.getInput('commit-messages-lines'))
+    await runAction(token, notifyAfter, commitMessageLines)
     return
   }
 
-  const commitMessageLines = Number(core.getInput('commit-messages-lines'))
+  if (!isNotifyReleaseIssue || !stateClosedNotPlanned) {
+    return
+  }
 
-  await runAction(token, notifyAfter, commitMessageLines)
+  await addComment(token, notifyAfter, issueNumber)
 }
 
 run().catch((err) => core.setFailed(err))

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@ const toolkit = require('actions-toolkit')
 const { context } = require('@actions/github')
 const { parseNotifyAfter } = require('./time-utils.js')
 const { runAction } = require('./release-notify-action')
-const { getIsSnoozingIssue, addSnoozingComment } = require('./issue.js')
+const {
+  getIsSnoozingIssue,
+  getIsClosingIssue,
+  addSnoozingComment,
+} = require('./issue.js')
 const { logInfo } = require('./log.js')
 
 async function run() {
@@ -24,6 +28,12 @@ async function run() {
     logInfo('Snoozing issue ...')
     const { number } = context.issue
     return addSnoozingComment(token, notifyAfter, number)
+  }
+
+  const isClosing = getIsClosingIssue(context)
+  if (isClosing) {
+    logInfo('Closing issue. Nothing to do ...')
+    return
   }
 
   logInfo('Workflow dispatched or release published ...')

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 const core = require('@actions/core')
 const toolkit = require('actions-toolkit')
+const { context } = require('@actions/github')
 const { parseNotifyAfter } = require('./time-utils.js')
 const { runAction } = require('./release-notify-action')
 
@@ -13,6 +14,13 @@ async function run() {
     core.getInput('notify-after'),
     core.getInput('stale-days')
   )
+
+  const isClosingIssue = context.eventName === 'closed'
+  if (isClosingIssue) {
+    console.log('eventName: ', context.eventName)
+    console.log('context: ', context)
+    return
+  }
 
   const commitMessageLines = Number(core.getInput('commit-messages-lines'))
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const toolkit = require('actions-toolkit')
 const { context } = require('@actions/github')
 const { parseNotifyAfter } = require('./time-utils.js')
 const { runAction } = require('./release-notify-action')
+const { getClosingIssueDetails, addComment } = require('./issue.js')
 
 async function run() {
   toolkit.logActionRefWarning()
@@ -15,10 +16,9 @@ async function run() {
     core.getInput('stale-days')
   )
 
-  const isClosingIssue = context.eventName === 'closed'
-  console.log('eventName: ', context.eventName)
-  console.log('context: ', context)
-  if (isClosingIssue) {
+  const { isClosing, issueId } = getClosingIssueDetails(context)
+  if (isClosing) {
+    await addComment(token, notifyAfter, issueId)
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,14 @@ async function run() {
     core.getInput('stale-days')
   )
 
-  const { isClosing, issueId } = getClosingIssueDetails(context)
+  const { isClosing, isNotifyReleaseIssue, stateClosedNotPlanned, issueId } =
+    getClosingIssueDetails(context)
   console.log('isClosing: ', isClosing)
   console.log('issueId: ', issueId)
-  if (isClosing) {
+  if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
     await addComment(token, notifyAfter, issueId)
+    return
+  } else if (isClosing) {
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,6 @@ async function run() {
 
   const { isClosing, isNotifyReleaseIssue, stateClosedNotPlanned, issueId } =
     getClosingIssueDetails(context)
-  console.log('isClosing: ', isClosing)
-  console.log('issueId: ', issueId)
   if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
     await addComment(token, notifyAfter, issueId)
     return

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ async function run() {
   )
 
   const isClosingIssue = context.eventName === 'closed'
+  console.log('eventName: ', context.eventName)
+  console.log('context: ', context)
   if (isClosingIssue) {
-    console.log('eventName: ', context.eventName)
-    console.log('context: ', context)
     return
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,14 @@ async function run() {
     core.getInput('stale-days')
   )
 
-  const { isClosing, isNotifyReleaseIssue, stateClosedNotPlanned, issueId } =
-    getClosingIssueDetails(context)
+  const {
+    isClosing,
+    isNotifyReleaseIssue,
+    stateClosedNotPlanned,
+    issueNumber,
+  } = getClosingIssueDetails(context)
   if (isClosing && isNotifyReleaseIssue && stateClosedNotPlanned) {
-    await addComment(token, notifyAfter, issueId)
+    await addComment(token, notifyAfter, issueNumber)
     return
   } else if (isClosing) {
     return

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ async function run() {
   )
 
   const { isClosing, issueId } = getClosingIssueDetails(context)
+  console.log('isClosing: ', isClosing)
+  console.log('issueId: ', issueId)
   if (isClosing) {
     await addComment(token, notifyAfter, issueId)
     return

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const { context } = require('@actions/github')
 const { parseNotifyAfter } = require('./time-utils.js')
 const { runAction } = require('./release-notify-action')
 const { getClosingIssueDetails, addComment } = require('./issue.js')
+const { logInfo } = require('./log.js')
 
 async function run() {
   toolkit.logActionRefWarning()
@@ -25,12 +26,16 @@ async function run() {
   } = getClosingIssueDetails(context)
 
   if (!isClosing) {
+    logInfo('Workflow dispatched or release published ...')
     const commitMessageLines = Number(core.getInput('commit-messages-lines'))
     await runAction(token, notifyAfter, commitMessageLines)
     return
   }
 
+  logInfo('Issue is closing ...')
+
   if (!isNotifyReleaseIssue || !stateClosedNotPlanned) {
+    logInfo('Nothing to do.')
     return
   }
 

--- a/src/issue.js
+++ b/src/issue.js
@@ -168,6 +168,21 @@ function getIsSnoozingIssue(context) {
   return isSnoozingIssue
 }
 
+function getIsClosingIssue(context) {
+  const { eventName, payload } = context
+  const { issue } = payload
+
+  if (!issue) {
+    return false
+  }
+
+  const { state } = issue
+
+  const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
+
+  return isClosing
+}
+
 async function addSnoozingComment(token, notifyAfter, issueNumber) {
   logInfo('Adding a snoozing comment to the issue.')
 
@@ -197,5 +212,6 @@ module.exports = {
   closeIssue,
   isSnoozed,
   getIsSnoozingIssue,
+  getIsClosingIssue,
   addSnoozingComment,
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -1,7 +1,7 @@
 'use strict'
 const github = require('@actions/github')
 const { logInfo } = require('./log')
-const { isStale } = require('./time-utils.js')
+const { isStale, getNotifyDate } = require('./time-utils.js')
 const fs = require('fs')
 const path = require('path')
 const { promisify } = require('util')
@@ -15,7 +15,6 @@ const {
   ISSUES_EVENT_NAME,
   STATE_CLOSED_NOT_PLANNED,
 } = require('./constants.js')
-const { notifyAfterToMs } = require('./time-utils.js')
 
 function registerHandlebarHelpers(config) {
   const { commitMessageLines } = config
@@ -180,7 +179,7 @@ function getClosingIssueDetails(context) {
 }
 
 async function addComment(token, notifyAfter, issueNumber) {
-  const notifyDate = notifyAfterToMs(notifyAfter)
+  const notifyDate = getNotifyDate(notifyAfter)
 
   const octokit = github.getOctokit(token)
   const { owner, repo } = github.context.repo
@@ -191,9 +190,7 @@ async function addComment(token, notifyAfter, issueNumber) {
       owner,
       repo,
       issue_number: issueNumber,
-      body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
-        notifyDate
-      )}.`,
+      body: `This issue has been snoozed. A new issue will be opened for you on ${notifyDate}.`,
     }
   )
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -104,7 +104,7 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const issueNo = await createIssue(token, issueBody)
+    const { number: issueNo } = await createIssue(token, issueBody)
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -153,14 +153,14 @@ function getClosingIssueDetails(context) {
 
   if (!issue) {
     return {
-      issueId: undefined,
+      issueNumber: undefined,
       isClosing: false,
       stateClosedNotPlanned: false,
       isNotifyReleaseIssue: false,
     }
   }
 
-  const { id, state, state_reason: stateReason, labels } = issue
+  const { number, state, state_reason: stateReason, labels } = issue
   const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
   const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
   const isNotifyReleaseIssue = labels.some(
@@ -168,7 +168,7 @@ function getClosingIssueDetails(context) {
   )
 
   const closingIssueDetails = {
-    issueId: id,
+    issueNumber: number,
     isClosing,
     stateClosedNotPlanned,
     isNotifyReleaseIssue,
@@ -179,7 +179,7 @@ function getClosingIssueDetails(context) {
   return closingIssueDetails
 }
 
-async function addComment(token, notifyAfter, issueId) {
+async function addComment(token, notifyAfter, issueNumber) {
   const notifyDate = notifyAfterToMs(notifyAfter)
 
   const octokit = github.getOctokit(token)
@@ -190,7 +190,7 @@ async function addComment(token, notifyAfter, issueId) {
     {
       owner,
       repo,
-      issue_number: issueId.toString(),
+      issue_number: issueNumber,
       body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
         notifyDate
       )}.`,

--- a/src/issue.js
+++ b/src/issue.js
@@ -104,8 +104,8 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const issueNo = await createIssue(token, issueBody)
-    console.log(issueNo)
+    const { data } = await createIssue(token, issueBody)
+    const { number: issueNo } = data
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -161,21 +161,22 @@ function getClosingIssueDetails(context) {
   }
 
   const { id, state, state_reason: stateReason, labels } = issue
-  console.log('id: ', id)
-  console.log('state: ', state)
-  console.log('state_reason: ', stateReason)
-  console.log('labels: ', labels)
-  console.log('stringified labels: ', JSON.stringify(labels))
   const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
   const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
-  const isNotifyReleaseIssue = labels.includes(ISSUE_LABEL)
+  const isNotifyReleaseIssue = labels.some(
+    (label) => label.name === ISSUE_LABEL
+  )
 
-  return {
+  const closingIssueDetails = {
     issueId: id,
     isClosing,
     stateClosedNotPlanned,
     isNotifyReleaseIssue,
   }
+
+  logInfo(closingIssueDetails)
+
+  return closingIssueDetails
 }
 
 async function addComment(token, notifyAfter, issueId) {

--- a/src/issue.js
+++ b/src/issue.js
@@ -173,12 +173,14 @@ function getClosingIssueDetails(context) {
     isNotifyReleaseIssue,
   }
 
-  logInfo(closingIssueDetails)
+  logInfo(`Closing issue details: ${closingIssueDetails}`)
 
   return closingIssueDetails
 }
 
 async function addComment(token, notifyAfter, issueNumber) {
+  logInfo('Adding a comment to the issue.')
+
   const notifyDate = getNotifyDate(notifyAfter)
 
   const octokit = github.getOctokit(token)
@@ -193,6 +195,8 @@ async function addComment(token, notifyAfter, issueNumber) {
       body: `This issue has been snoozed. A new issue will be opened for you on ${notifyDate}.`,
     }
   )
+
+  logInfo('Comment added to the issue.')
 }
 
 module.exports = {

--- a/src/issue.js
+++ b/src/issue.js
@@ -147,40 +147,29 @@ async function isSnoozed(token, latestReleaseDate, notifyDate) {
   return !isStale(closedNotifyIssues[0].closed_at, notifyDate)
 }
 
-function getClosingIssueDetails(context) {
+function getIsSnoozingIssue(context) {
   const { eventName, payload } = context
   const { issue } = payload
 
   if (!issue) {
-    return {
-      issueNumber: undefined,
-      isClosing: false,
-      stateClosedNotPlanned: false,
-      isNotifyReleaseIssue: false,
-    }
+    return false
   }
 
-  const { number, state, state_reason: stateReason, labels } = issue
+  const { state, state_reason: stateReason, labels } = issue
+
   const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
   const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
   const isNotifyReleaseIssue = labels.some(
     (label) => label.name === ISSUE_LABEL
   )
 
-  const closingIssueDetails = {
-    issueNumber: number,
-    isClosing,
-    stateClosedNotPlanned,
-    isNotifyReleaseIssue,
-  }
-
-  logInfo(`Closing issue details: ${JSON.stringify(closingIssueDetails)}`)
-
-  return closingIssueDetails
+  const isSnoozingIssue =
+    isClosing && stateClosedNotPlanned && isNotifyReleaseIssue
+  return isSnoozingIssue
 }
 
-async function addComment(token, notifyAfter, issueNumber) {
-  logInfo('Adding a comment to the issue.')
+async function addSnoozingComment(token, notifyAfter, issueNumber) {
+  logInfo('Adding a snoozing comment to the issue.')
 
   const notifyDate = getNotifyDate(notifyAfter)
 
@@ -197,7 +186,7 @@ async function addComment(token, notifyAfter, issueNumber) {
     }
   )
 
-  logInfo('Comment added to the issue.')
+  logInfo('Snoozing comment added to the issue.')
 }
 
 module.exports = {
@@ -207,6 +196,6 @@ module.exports = {
   createOrUpdateIssue,
   closeIssue,
   isSnoozed,
-  getClosingIssueDetails,
-  addComment,
+  getIsSnoozingIssue,
+  addSnoozingComment,
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -104,7 +104,8 @@ async function createOrUpdateIssue(
     await updateLastOpenPendingIssue(token, issueBody, pendingIssue.number)
     logInfo(`Issue ${pendingIssue.number} has been updated`)
   } else {
-    const { number: issueNo } = await createIssue(token, issueBody)
+    const issueNo = await createIssue(token, issueBody)
+    console.log(issueNo)
     logInfo(`New issue has been created. Issue No. - ${issueNo}`)
   }
 }
@@ -173,7 +174,7 @@ function getClosingIssueDetails(context) {
     isNotifyReleaseIssue,
   }
 
-  logInfo(`Closing issue details: ${closingIssueDetails}`)
+  logInfo(`Closing issue details: ${JSON.stringify(closingIssueDetails)}`)
 
   return closingIssueDetails
 }

--- a/src/issue.js
+++ b/src/issue.js
@@ -190,7 +190,7 @@ async function addComment(token, notifyAfter, issueId) {
     {
       owner,
       repo,
-      issue_number: issueId,
+      issue_number: issueId.toString(),
       body: `This issue has been snoozed. A new issue will be opened for you on ${new Date(
         notifyDate
       )}.`,

--- a/src/issue.js
+++ b/src/issue.js
@@ -155,19 +155,26 @@ function getClosingIssueDetails(context) {
     return {
       issueId: undefined,
       isClosing: false,
+      stateClosedNotPlanned: false,
+      isNotifyReleaseIssue: false,
     }
   }
 
   const { id, state, state_reason: stateReason, labels } = issue
-  const isClosing =
-    eventName === ISSUES_EVENT_NAME &&
-    state === STATE_CLOSED &&
-    stateReason === STATE_CLOSED_NOT_PLANNED &&
-    labels.includes(ISSUE_LABEL)
+  console.log('id: ', id)
+  console.log('state: ', state)
+  console.log('state_reason: ', stateReason)
+  console.log('labels: ', labels)
+  console.log('stringified labels: ', JSON.stringify(labels))
+  const isClosing = eventName === ISSUES_EVENT_NAME && state === STATE_CLOSED
+  const stateClosedNotPlanned = stateReason === STATE_CLOSED_NOT_PLANNED
+  const isNotifyReleaseIssue = labels.includes(ISSUE_LABEL)
 
   return {
     issueId: id,
     isClosing,
+    stateClosedNotPlanned,
+    isNotifyReleaseIssue,
   }
 }
 

--- a/src/time-utils.js
+++ b/src/time-utils.js
@@ -43,10 +43,21 @@ function parseNotifyAfter(notifyAfter, staleDays) {
   return isNaN(Number(staleDays)) ? staleDays : staleDaysToStr(staleDays)
 }
 
+function getNotifyDate(input) {
+  const stringToMs = ms(input)
+
+  if (isNaN(stringToMs)) {
+    throw new Error('Invalid time value')
+  }
+
+  return new Date(Date.now() + stringToMs)
+}
+
 module.exports = {
   isSomeCommitStale,
   isStale,
   parseNotifyAfter,
   notifyAfterToMs,
+  getNotifyDate,
   staleDaysToStr,
 }

--- a/test/issue.spec.js
+++ b/test/issue.spec.js
@@ -321,6 +321,35 @@ test('getIsSnoozingIssue returns false if the issue is not closing', () => {
   expect(isSnoozingIssue).toEqual(false)
 })
 
+test('getIsClosingIssue returns true if the issue is closing', () => {
+  const mockedContext = {
+    eventName: 'issues',
+    payload: {
+      issue: {
+        number: 1,
+        state: 'closed',
+        state_reason: 'complete',
+        labels: [],
+      },
+    },
+  }
+
+  const isClosingIssue = issue.getIsClosingIssue(mockedContext)
+
+  expect(isClosingIssue).toEqual(true)
+})
+
+test('getIsClosingIssue returns false if the issue is not closing', () => {
+  const mockedContext = {
+    eventName: 'workflow_dispatch',
+    payload: {},
+  }
+
+  const isClosingIssue = issue.getIsClosingIssue(mockedContext)
+
+  expect(isClosingIssue).toEqual(false)
+})
+
 test('Add a snoozing comment to a closing issue', async () => {
   const request = jest.fn()
   getOctokit.mockReturnValue({ request })

--- a/test/issue.spec.js
+++ b/test/issue.spec.js
@@ -108,6 +108,11 @@ test('Close an issue', async () => {
 test('Create an issue when no existing issue exists', async () => {
   const create = jest.fn()
   getOctokit.mockReturnValue({ rest: { issues: { create } } })
+  create.mockResolvedValue({
+    data: {
+      number: 1,
+    },
+  })
 
   await issue.createOrUpdateIssue(
     token,
@@ -142,6 +147,11 @@ test('Update an issue when exists', async () => {
 test('Create issue body that contains commits shortened SHA identifiers', async () => {
   const create = jest.fn()
   getOctokit.mockReturnValue({ rest: { issues: { create } } })
+  create.mockResolvedValue({
+    data: {
+      number: 1,
+    },
+  })
 
   await issue.createOrUpdateIssue(
     token,
@@ -213,6 +223,11 @@ test('', async () => {
 test('Creates a snooze issue when no pending', async () => {
   const create = jest.fn()
   getOctokit.mockReturnValue({ rest: { issues: { create } } })
+  create.mockResolvedValue({
+    data: {
+      number: 1,
+    },
+  })
 
   await issue.createOrUpdateIssue(
     token,

--- a/test/time-utils.spec.js
+++ b/test/time-utils.spec.js
@@ -6,6 +6,7 @@ const {
   isStale,
   parseNotifyAfter,
   staleDaysToStr,
+  getNotifyDate,
 } = require('../src/time-utils.js')
 
 const {
@@ -126,4 +127,15 @@ test('parseNotifyAfter numeric notify-after', () => {
   expect(parseNotifyAfter('0', undefined)).toEqual('0 ms')
 
   expect(parseNotifyAfter('-1', undefined)).toEqual('-1 ms')
+})
+
+test('getNotifyDate should return a valid date object', () => {
+  const input = '1 day'
+  const result = getNotifyDate(input)
+  expect(result).toBeInstanceOf(Date)
+})
+
+test('getNotifyDate should throw an error when input is a string in an invalid format', () => {
+  const input = 'invalid input'
+  expect(() => getNotifyDate(input)).toThrow('Invalid time value')
 })


### PR DESCRIPTION
It closes #393 

### Main changes:

- added a new trigger on `issues` `[closed]` in the Github action workflow
- added a new check in the main file so that we can handle the new trigger only if these conditions are met:
    - `event_name == 'issues' && state == 'closed' && state_reason == 'not_planned' && issue_label == 'notify-release'`
- if the above conditions are met the new `addComment` functionality will be executed.
- added unit tests to reach 100% code coverage.

### Tests:

Below you can find the list of tests I performed to check the new feature:

1. run manually the action: a new issue is created as expected :white_check_mark:
2. run the action after a release has been published: a new issue is created only if new commits are present :white_check_mark:
3. close the issue as complete: the action is triggered but nothing happens, because we only handle the closing event on `not_planned` :white_check_mark:
4. close the issue as not_planned: the action is triggered and a new comment is added to the issue :white_check_mark:

<details>
<summary>Test screenshots:</summary>

1. run manually the action
<img width="425" alt="image" src="https://user-images.githubusercontent.com/6604111/215691063-45eb5b53-bd8f-40a8-9c73-c45724825049.png">

2. run the action after a release has been published
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/6604111/215691514-d5cd66e6-9ab7-43e1-8588-2ddf816a6b7d.png">

3. close the issue as complete
<img width="1041" alt="image" src="https://user-images.githubusercontent.com/6604111/215690276-ac29c939-4a42-48ff-a6e0-094fd09b1570.png">

4. close the issue as not_planned
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/6604111/215690851-e15ac20d-6edf-4db2-a0ef-0ccf37489ea8.png">

<img width="916" alt="image" src="https://user-images.githubusercontent.com/6604111/215690940-18d83d78-3ea0-4dd5-abb2-6de335e64ff1.png">
</details>
