### PR TITLE
add sanitize commit message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -70814,17 +70814,26 @@ async function getUnreleasedCommits(token, latestReleaseDate, notifyDate) {
   const octokit = github.getOctokit(token)
   const { owner, repo } = github.context.repo
 
-  const { data: unreleasedCommits } = await octokit.request(
-    `GET /repos/{owner}/{repo}/commits`,
-    {
-      owner,
-      repo,
-      since: latestReleaseDate,
-    }
-  )
-  return isSomeCommitStale(unreleasedCommits, notifyDate)
-    ? unreleasedCommits
-    : []
+  const { data } = await octokit.request(`GET /repos/{owner}/{repo}/commits`, {
+    owner,
+    repo,
+    since: latestReleaseDate,
+  })
+
+  const unreleasedCommits = isSomeCommitStale(data, notifyDate) ? data : []
+
+  const commits = sanitizeCommitMessage(unreleasedCommits)
+
+  return commits
+}
+
+function sanitizeCommitMessage(commits) {
+  return commits.map((commit) => {
+    commit.commit.message = commit.commit.message
+      .replace(/\n/g, '') // removes new line characters
+      .replace(/\s+/g, ' ') // removes additional space characters
+    return commit
+  })
 }
 
 module.exports = {

--- a/test/testData.js
+++ b/test/testData.js
@@ -194,12 +194,7 @@ const unreleasedCommitsData1 = [
         name: 'Sameer Srivastava',
         date: '2021-04-28T09:27:24Z',
       },
-      message: `variable changed
-    
-    
-this message has multiple lines
-
-`,
+      message: `variable changed this message has multiple lines`,
     },
   },
   {


### PR DESCRIPTION
Fixes #417 (partially)

### Main changes:

- This fix introduces a new function called `sanitizeCommitMessage` that accepts unsanitized commis as input and cleans the `commit.message` by removing new line characters and extra spaces between words.
- Adapted tests to include this scenario.

### Missing checks:

- check if the change above is correct, given the commit-message-line input
- check with some real tests (from a repo using this branch) if the issue described in #417 is solved